### PR TITLE
Fix deprecated top-level `multi_instance` parameter

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   blackbox_exporter:
-    multi_instance: true
-    =_metadata: {}
+    =_metadata:
+      multi_instance: true
     charts:
       blackbox_exporter: 5.3.1
     helmValues: {}


### PR DESCRIPTION
With commodore v1.0.0 the `multi_instance` parameter has been moved to
the `_metadata` parameter.

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
