### PR TITLE
Fix/service monitor sync problem

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "blackbox-exporter",
       "slug": "blackbox-exporter",
       "parameter_key": "blackbox_exporter",
-      "test_cases": "defaults",
+      "test_cases": "defaults servicemonitor-added-fields",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - servicemonitor-added-fields
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -48,6 +49,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - servicemonitor-added-fields
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -50,4 +50,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml
+test_instances = tests/defaults.yml tests/servicemonitor-added-fields.yml

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -4,7 +4,19 @@ local params = inv.parameters.blackbox_exporter;
 local argocd = import 'lib/argocd.libjsonnet';
 local instance = inv.parameters._instance;
 
-local app = argocd.App(instance, params.namespace);
+local app = argocd.App(instance, params.namespace) {
+  spec+: {
+    ignoreDifferences: [
+      {
+        group: 'monitoring.coreos.com',
+        kind: 'ServiceMonitor',
+        jqPathExpressions: [
+          '.spec.endpoints[].metricRelabelings[]',
+        ],
+      },
+    ],
+  },
+};
 
 {
   [instance]: app,

--- a/tests/golden/defaults/blackbox-exporter/apps/blackbox-exporter.yaml
+++ b/tests/golden/defaults/blackbox-exporter/apps/blackbox-exporter.yaml
@@ -1,0 +1,6 @@
+spec:
+  ignoreDifferences:
+    - group: monitoring.coreos.com
+      jqPathExpressions:
+        - .spec.endpoints[].metricRelabelings[]
+      kind: ServiceMonitor

--- a/tests/golden/servicemonitor-added-fields/blackbox-exporter/apps/blackbox-exporter.yaml
+++ b/tests/golden/servicemonitor-added-fields/blackbox-exporter/apps/blackbox-exporter.yaml
@@ -1,0 +1,6 @@
+spec:
+  ignoreDifferences:
+    - group: monitoring.coreos.com
+      jqPathExpressions:
+        - .spec.endpoints[].metricRelabelings[]
+      kind: ServiceMonitor

--- a/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/10_blackbox_exporter_helmchart/prometheus-blackbox-exporter/templates/configmap.yaml
+++ b/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/10_blackbox_exporter_helmchart/prometheus-blackbox-exporter/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  blackbox.yaml: "modules:\n  http_2xx:\n    http:\n      follow_redirects: true\n\
+    \      preferred_ip_protocol: ip4\n      valid_http_versions:\n      - HTTP/1.1\n\
+    \      - HTTP/2.0\n    prober: http\n    timeout: 5s\n  http_check:\n    http:\n\
+    \      follow_redirects: true\n      preferred_ip_protocol: ip4\n      tls_config:\n\
+    \        insecure_skip_verify: true\n      valid_http_versions:\n      - HTTP/1.1\n\
+    \      - HTTP/2.0\n      valid_status_codes:\n      - 200\n      - 401\n    prober:\
+    \ http\n    timeout: 5s\n"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: blackbox-exporter
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: prometheus-blackbox-exporter
+    app.kubernetes.io/version: 0.23.0
+    helm.sh/chart: prometheus-blackbox-exporter-7.2.0
+  name: blackbox-exporter-prometheus-blackbox-exporter
+  namespace: syn-blackbox-exporter

--- a/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/10_blackbox_exporter_helmchart/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/10_blackbox_exporter_helmchart/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: blackbox-exporter
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: prometheus-blackbox-exporter
+    app.kubernetes.io/version: 0.23.0
+    helm.sh/chart: prometheus-blackbox-exporter-7.2.0
+  name: blackbox-exporter-prometheus-blackbox-exporter
+  namespace: syn-blackbox-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: blackbox-exporter
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: b90d5663387c997a691e9ba48020352a2d9c5d9ab99c2aac37c9385bfd8237e8
+      labels:
+        app.kubernetes.io/instance: blackbox-exporter
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: prometheus-blackbox-exporter
+        app.kubernetes.io/version: 0.23.0
+        helm.sh/chart: prometheus-blackbox-exporter-7.2.0
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - --config.file=/config/blackbox.yaml
+          env: null
+          image: prom/blackbox-exporter:v0.22.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          name: blackbox-exporter
+          ports:
+            - containerPort: 9115
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /config
+              name: config
+      hostNetwork: false
+      restartPolicy: Always
+      securityContext: {}
+      serviceAccountName: blackbox-exporter-prometheus-blackbox-exporter
+      volumes:
+        - configMap:
+            name: blackbox-exporter-prometheus-blackbox-exporter
+          name: config

--- a/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/10_blackbox_exporter_helmchart/prometheus-blackbox-exporter/templates/service.yaml
+++ b/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/10_blackbox_exporter_helmchart/prometheus-blackbox-exporter/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: blackbox-exporter
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: prometheus-blackbox-exporter
+    app.kubernetes.io/version: 0.23.0
+    helm.sh/chart: prometheus-blackbox-exporter-7.2.0
+  name: blackbox-exporter-prometheus-blackbox-exporter
+  namespace: syn-blackbox-exporter
+spec:
+  ports:
+    - name: http
+      port: 9115
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: blackbox-exporter
+    app.kubernetes.io/name: prometheus-blackbox-exporter
+  type: ClusterIP

--- a/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/10_blackbox_exporter_helmchart/prometheus-blackbox-exporter/templates/serviceaccount.yaml
+++ b/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/10_blackbox_exporter_helmchart/prometheus-blackbox-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: blackbox-exporter
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: prometheus-blackbox-exporter
+    app.kubernetes.io/version: 0.23.0
+    helm.sh/chart: prometheus-blackbox-exporter-7.2.0
+  name: blackbox-exporter-prometheus-blackbox-exporter
+  namespace: syn-blackbox-exporter

--- a/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/10_blackbox_exporter_helmchart/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/10_blackbox_exporter_helmchart/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,122 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/instance: blackbox-exporter
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: prometheus-blackbox-exporter
+    app.kubernetes.io/version: 0.23.0
+    helm.sh/chart: prometheus-blackbox-exporter-7.2.0
+  name: blackbox-exporter-prometheus-blackbox-exporter-http
+  namespace: syn-blackbox-exporter
+spec:
+  endpoints:
+    - interval: 30s
+      metricRelabelings:
+        - replacement: https://my-url
+          sourceLabels:
+            - instance
+          targetLabel: instance
+        - replacement: http
+          sourceLabels:
+            - target
+          targetLabel: target
+      params:
+        module:
+          - http_check
+        target:
+          - https://my-url
+      path: /probe
+      port: http
+      scheme: http
+      scrapeTimeout: 30s
+  jobLabel: blackbox-exporter
+  namespaceSelector:
+    matchNames:
+      - syn-blackbox-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: blackbox-exporter
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/instance: blackbox-exporter
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: prometheus-blackbox-exporter
+    app.kubernetes.io/version: 0.23.0
+    helm.sh/chart: prometheus-blackbox-exporter-7.2.0
+  name: blackbox-exporter-prometheus-blackbox-exporter-openid
+  namespace: syn-blackbox-exporter
+spec:
+  endpoints:
+    - interval: 30s
+      metricRelabelings:
+        - replacement: https://my-url:13342/openid/
+          sourceLabels:
+            - instance
+          targetLabel: instance
+        - replacement: openid
+          sourceLabels:
+            - target
+          targetLabel: target
+      params:
+        module:
+          - http_check
+        target:
+          - https://my-url:13342/openid/
+      path: /probe
+      port: http
+      scheme: http
+      scrapeTimeout: 30s
+  jobLabel: blackbox-exporter
+  namespaceSelector:
+    matchNames:
+      - syn-blackbox-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: blackbox-exporter
+      app.kubernetes.io/name: prometheus-blackbox-exporter
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/instance: blackbox-exporter
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: prometheus-blackbox-exporter
+    app.kubernetes.io/version: 0.23.0
+    helm.sh/chart: prometheus-blackbox-exporter-7.2.0
+  name: blackbox-exporter-prometheus-blackbox-exporter-api
+  namespace: syn-blackbox-exporter
+spec:
+  endpoints:
+    - interval: 30s
+      metricRelabelings:
+        - replacement: https://my-url:13344/api
+          sourceLabels:
+            - instance
+          targetLabel: instance
+        - replacement: api
+          sourceLabels:
+            - target
+          targetLabel: target
+      params:
+        module:
+          - http_check
+        target:
+          - https://my-url:13344/api
+      path: /probe
+      port: http
+      scheme: http
+      scrapeTimeout: 30s
+  jobLabel: blackbox-exporter
+  namespaceSelector:
+    matchNames:
+      - syn-blackbox-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: blackbox-exporter
+      app.kubernetes.io/name: prometheus-blackbox-exporter

--- a/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/syn-blackbox-exporter.yaml
+++ b/tests/golden/servicemonitor-added-fields/blackbox-exporter/blackbox-exporter/syn-blackbox-exporter.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: syn-blackbox-exporter
+  name: syn-blackbox-exporter

--- a/tests/servicemonitor-added-fields.yml
+++ b/tests/servicemonitor-added-fields.yml
@@ -1,0 +1,3 @@
+# Overwrite parameters here
+
+# parameters: {...}

--- a/tests/servicemonitor-added-fields.yml
+++ b/tests/servicemonitor-added-fields.yml
@@ -1,3 +1,28 @@
 # Overwrite parameters here
 
-# parameters: {...}
+parameters:
+  blackbox_exporter:
+    helmValues:
+      config:
+        modules:
+          http_check:
+            prober: http
+            timeout: 5s
+            http:
+              valid_status_codes: [200, 401]
+              valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+              follow_redirects: true
+              preferred_ip_protocol: "ip4"
+              tls_config:
+                insecure_skip_verify: true
+      serviceMonitor:
+        enabled: true
+        defaults:
+          module: http_check
+        targets:
+          - name: http
+            url: https://my-url
+          - name: openid
+            url: https://my-url:13342/openid/
+          - name: api
+            url: https://my-url:13344/api


### PR DESCRIPTION
Rendered manifests for certain ServiceMonitor objects look like this:
```
spec:
  endpoints:
    - interval: 30s
      metricRelabelings:
        - replacement: https://my-url
          sourceLabels:
            - instance
          targetLabel: instance
        - replacement: http
          sourceLabels:
            - target
          targetLabel: target
```

The prometheus operator adds certain fields, which causes a sync error:
```
spec:
  endpoints:
  - interval: 30s
    metricRelabelings:
    - action: replace        # <-- here
      replacement: https://my-url
      sourceLabels:
      - instance
      targetLabel: instance
    - action: replace        # <-- here
      replacement: http
      sourceLabels:
      - target
      targetLabel: target
```

## Checklist

- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
