### PR TITLE
chore: migrate Renovate config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "ignorePaths": [
     ".github/**"


### PR DESCRIPTION
## Summary

- migrate Renovate's deprecated `config:base` preset to `config:recommended`
- keep the existing ignore paths, labels, post-upgrade task settings, notification suppression, and package rules unchanged

## Context

The current Dependency Dashboard (#3) reports `Config Migration Needed`. This is a small public-config-only cleanup so Renovate no longer needs to flag the deprecated preset.

## Validation

- `python3 -m json.tool renovate.json`
